### PR TITLE
ci: remove 'needs' from docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,6 @@ jobs:
     name: "Docker"
     if: ${{ github.repository_owner == 'hemilabs' }}
     runs-on: "ubuntu-latest"
-    needs: [ "prepare" ]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Fixes `docker` workflow not starting because of `needs` being set on the only job.
This was left over from using another workflow in heminetwork as a base, and is not needed.
