### PR TITLE
do not change user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,5 @@ ARG BUILDNUM=""
 
 LABEL commit="$COMMIT" version="$VERSION" buildnum="$BUILDNUM"
 
-USER geth:geth
 WORKDIR /go-ethereum/
 ENTRYPOINT ["/usr/local/bin/geth"]


### PR DESCRIPTION
we mount file systems to docker containers in k8s, if we change the user we don't have permissions to write to them

if we don't change the user, we will get an error similar to

```
Fatal: Failed to create the protocol stack: mkdir /data/geth/geth-5: permission denied
```