### PR TITLE
fix(feehistory): take into account for PopPayoutTxType to avoid negative rewards

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -108,7 +108,13 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 
 	sorter := make([]txGasAndReward, len(bf.block.Transactions()))
 	for i, tx := range bf.block.Transactions() {
-		reward, _ := tx.EffectiveGasTip(bf.block.BaseFee())
+		var reward *big.Int
+		if tx.Type() == types.PopPayoutTxType {
+			reward = new(big.Int)
+		} else {
+			reward, _ = tx.EffectiveGasTip(bf.block.BaseFee())
+		}
+
 		sorter[i] = txGasAndReward{gasUsed: bf.receipts[i].GasUsed, reward: reward}
 	}
 	slices.SortStableFunc(sorter, func(a, b txGasAndReward) int {


### PR DESCRIPTION
geth can return negative rewards for eth_feeHistory which is not valid

e.g.
```
curl --request POST \
     --url https://testnet.rpc.hemi.network/rpc \
     --header 'accept: application/json' \
     --header 'content-type: application/json' \
     --data '
{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "eth_feeHistory",
  "params": [
    1,
    "0x272f8b",
    [25]
  ]
}'
```

this happens whenever in a block there's a system tx of type `PopPayoutTxType` which hemi fork added on top of the optimism ones `DepositTxType`

e.g. https://testnet.explorer.hemi.xyz/tx/0x078fca90fcd1215f5c0e402f690025d6b84803db1b201e224f95de919c2d8d21

the fix normalize these new system tx as optimism ones `DepositTxType`, returning 0 as reward

see https://github.com/hemilabs/op-geth/blob/hemi/core/types/transaction.go#L427-L429

the fix has been applied at the higher level (only for the fee_history method), to consider to put directly in the tx.effectiveGasTip method but to check there are no consequences with other logics
