### PR TITLE
brute force indexing upon op-geth startup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,6 @@
 name: "Docker"
 on:
   push:
-    branches: [ "hemi" ]
 
 concurrency:
   group: "docker-${{ github.workflow }}-${{ github.event.number || github.ref }}"

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -353,6 +353,34 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 					continue
 				}
 
+				log.Info("block is available %s:%d", blockHeaderBest.BlockHash().String(), height)
+
+				log.Info("done downloading blocks, now will sync indexers to best")
+
+				for {
+					missing, err := vm.TBCFullNode.BlocksMissing(ctx.Context, 100)
+					if err != nil {
+						log.Crit(fmt.Sprintf("could not get blocks missing: %s", err))
+					}
+
+					if len(missing) == 0 {
+						break
+					}
+
+					for _, m := range missing {
+						log.Info("found missing block, will atttempt download: %s:%d", m.Hash, m.Height)
+						_, err := vm.TBCFullNode.DownloadBlockFromRandomPeers(ctx.Context, m.Hash, 1)
+						if err != nil {
+							log.Crit(fmt.Sprintf("could not download block from random peer: %s", err))
+						}
+					}
+				}
+
+				bestBlockHash := blockHeaderBest.BlockHash()
+				if err := vm.TBCFullNode.SyncIndexersToHash(ctx.Context, &bestBlockHash); err != nil {
+					log.Crit(fmt.Sprintf("could not sync indexers to best: %s", err))
+				}
+
 				break
 			}
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -307,7 +307,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 						log.Crit(fmt.Sprintf("error getting block header best: %s", err))
 					}
 
-					log.Info(fmt.Sprintf("the current best block height is %d", bh))
+					log.Trace(fmt.Sprintf("the current best block height is %d", bh))
 
 					if bh < genesisHeight {
 						continue
@@ -331,7 +331,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 				break
 			}
 
-			log.Info("done getting hvm genesis header, waiting until we have all of the blocks")
+			log.Trace("done getting hvm genesis header, waiting until we have all of the blocks")
 
 			// grab the current best block, we will then wait until we have all full blocks up to
 			// this one
@@ -350,14 +350,14 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 				// if it's not available, wait until it is
 				if !available {
-					log.Info(fmt.Sprintf("block not available, will wait: %s:%d", blockHeaderBest.BlockHash().String(), height))
+					log.Trace(fmt.Sprintf("block not available, will wait: %s:%d", blockHeaderBest.BlockHash().String(), height))
 					time.Sleep(5 * time.Second)
 					continue
 				}
 
-				log.Info("block is available %s:%d", blockHeaderBest.BlockHash().String(), height)
+				log.Trace(fmt.Sprintf("block is available %s:%d", blockHeaderBest.BlockHash().String(), height))
 
-				log.Info("done downloading blocks, now will sync indexers to best")
+				log.Trace("done downloading blocks, now will sync indexers to best")
 
 				// wait until we have fixed all of the missing blocks
 				for {
@@ -372,7 +372,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 					// for each missing block, try to redownload
 					for _, m := range missing {
-						log.Info("found missing block, will atttempt download: %s:%d", m.Hash, m.Height)
+						log.Trace(fmt.Sprintf("found missing block, will atttempt download: %s:%d", m.Hash, m.Height))
 						_, err := vm.TBCFullNode.DownloadBlockFromRandomPeers(ctx.Context, m.Hash, 1)
 						if err != nil {
 							log.Crit(fmt.Sprintf("could not download block from random peer: %s", err))

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -353,33 +353,6 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 					continue
 				}
 
-				available, missing, _, err := vm.TBCBlocksAvailableToHeader(ctx.Context, blockHeaderBest)
-				if err != nil {
-					log.Crit(fmt.Sprintf("error occurred checking if blocks available: %s", err))
-				}
-
-				if missing != nil {
-					for _, m := range *missing {
-						log.Info(fmt.Sprintf("refecting: %s", m.BlockHash().String()))
-						vm.TBCAttemptBlockRefetch(ctx.Context, &m)
-					}
-				}
-
-				if !available {
-					log.Info(fmt.Sprintf("block not available to header, will wait: %s:%d", blockHeaderBest.BlockHash().String(), height))
-					time.Sleep(5 * time.Second)
-					continue
-				}
-
-				log.Info("block is available %s:%d", blockHeaderBest.BlockHash().String(), height)
-
-				log.Info("done downloading blocks, now will sync indexers to best")
-
-				bestBlockHash := blockHeaderBest.BlockHash()
-				if err := vm.TBCFullNode.SyncIndexersToHash(ctx.Context, &bestBlockHash); err != nil {
-					log.Crit(fmt.Sprintf("could not sync indexers to best: %s", err))
-				}
-
 				break
 			}
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -29,6 +29,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/hemilabs/heminetwork/cmd/btctool/bdf"
 	"github.com/hemilabs/heminetwork/service/tbc"
@@ -294,7 +295,76 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		// rather than working correctly until then and freezing at activation until TBC is caught up.
 		// Would rather have node delay full startup to fully sync TBC to required genesis height
 		// than startup without full information and later freeze at hVM Phase 0 activation time.
+
 		for {
+
+			// wait until we have a high degree of confidence that we have
+			// chain up to the hvm genesis block indexed
+			for {
+				select {
+				case <-time.After(1 * time.Second):
+					bh, _, err := vm.TBCFullNode.BlockHeaderBest(ctx.Context)
+					if err != nil {
+						log.Crit(fmt.Sprintf("error getting block header best: %s", err))
+					}
+
+					log.Info(fmt.Sprintf("the current best block height is %d", bh))
+
+					if bh < genesisHeight {
+						continue
+					}
+
+					ghh := genesisHeader.BlockHash()
+					// we're above genesis height, but are we on the best chain with genesis?
+					_, height, err := vm.TBCFullNode.BlockHeaderByHash(ctx.Context, &ghh)
+					if err != nil {
+						log.Crit(fmt.Sprintf("could not get block by hash: %s", err))
+					}
+
+					if height != genesisHeight {
+						log.Crit(fmt.Sprintf("mismatched genesis heights %d != %d", height, genesisHeight))
+					}
+
+					break
+				case <-ctx.Context.Done():
+					return nil, nil
+				}
+				break
+			}
+
+			log.Info("done getting hvm genesis header, waiting until we have all of the blocks")
+
+			// wait until we have full blocks up to the best, this is a bit unsafe since we
+			// don't check every block, but we have a high degree of confidence we have full blocks
+			height, blockHeaderBest, err := vm.TBCFullNode.BlockHeaderBest(ctx.Context)
+			if err != nil {
+				log.Crit(fmt.Sprintf("error getting block header best: %s", err))
+			}
+
+			for {
+				bhh := blockHeaderBest.BlockHash()
+				avail, err := vm.TBCFullNode.FullBlockAvailable(ctx.Context, &bhh)
+				if err != nil {
+					log.Crit(fmt.Sprintf("could not determine if full block available: %s", err))
+				}
+
+				if !avail {
+					log.Info(fmt.Sprintf("block not available, will wait: %s:%d", blockHeaderBest.BlockHash().String(), height))
+					time.Sleep(5 * time.Second)
+					continue
+				}
+
+				log.Info("block is available %s:%d", blockHeaderBest.BlockHash().String(), height)
+
+				log.Info("done downloading blocks, now will sync indexers to best")
+
+				if err := vm.TBCFullNode.SyncIndexersToBest(ctx.Context); err != nil {
+					log.Crit(fmt.Sprintf("could not sync indexers to best: %s", err))
+				}
+
+				break
+			}
+
 			bh, bhb, err := vm.TBCFullNode.BlockHeaderBest(ctx.Context)
 			if err != nil {
 				// Being unable to retrieve the best block header known by the TBC Full Node indiciates
@@ -304,17 +374,6 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 			log.Info(fmt.Sprintf("got best block header of %s",
 				bhb.BlockHash().String()))
-
-			if genesisHeight < 5000 {
-				time.Sleep(10 * time.Second)
-				log.Info("genesis height is less than 5000, brute-force sync to genesis header")
-				_bh := genesisHeader.BlockHash()
-				err = vm.TBCFullNode.SyncIndexersToHash(ctx.Context, &_bh)
-				if err != nil {
-					log.Crit(fmt.Sprintf("error occurred indexing to the hvm genesis header (%s): %s", genesisHeader.BlockHash().String(), err))
-				}
-
-			}
 
 			// Get the current indexer information and make sure both indexers are at the same height
 			syncInfo = *vm.GetTBCFullNodeSyncStatus()

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -360,8 +360,8 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 				if len(missing) > 0 {
 					for _, m := range missing {
-						log.Info(fmt.Sprintf("refecting: %s", missing.BlockHash().String()))
-						vm.TBCAttemptBlockRefetch(ctx.Context, missing)
+						log.Info(fmt.Sprintf("refecting: %s", m.BlockHash().String()))
+						vm.TBCAttemptBlockRefetch(ctx.Context, m)
 					}
 				}
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -304,7 +304,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 				case <-time.After(1 * time.Second):
 					bh, _, err := vm.TBCFullNode.BlockHeaderBest(ctx.Context)
 					if err != nil {
-						log.Crit(fmt.Sprintf("error getting block header best: %s", err))
+						log.Crit(fmt.Sprintf("error getting best block header: %s", err))
 					}
 
 					log.Trace(fmt.Sprintf("the current best block height is %d", bh))
@@ -337,7 +337,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			// this one
 			height, blockHeaderBest, err := vm.TBCFullNode.BlockHeaderBest(ctx.Context)
 			if err != nil {
-				log.Crit(fmt.Sprintf("error getting block header best: %s", err))
+				log.Crit(fmt.Sprintf("error getting best block header: %s", err))
 			}
 
 			for {

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -29,7 +29,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/hemilabs/heminetwork/cmd/btctool/bdf"
 	"github.com/hemilabs/heminetwork/service/tbc"
@@ -358,7 +357,8 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 				log.Info("done downloading blocks, now will sync indexers to best")
 
-				if err := vm.TBCFullNode.SyncIndexersToBest(ctx.Context); err != nil {
+				bestBlockHash := blockHeaderBest.BlockHash()
+				if err := vm.TBCFullNode.SyncIndexersToHash(ctx.Context, &bestBlockHash); err != nil {
 					log.Crit(fmt.Sprintf("could not sync indexers to best: %s", err))
 				}
 

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -304,10 +304,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 				case <-time.After(1 * time.Second):
 					bh, _, err := vm.TBCFullNode.BlockHeaderBest(ctx.Context)
 					if err != nil {
-						log.Crit(fmt.Sprintf("error getting best block header: %s", err))
+						log.Crit("error getting best block header", "error", err)
 					}
 
-					log.Trace(fmt.Sprintf("the current best block height is %d", bh))
+					log.Trace("the current best block height", "height", bh)
 
 					if bh < genesisHeight {
 						continue
@@ -317,11 +317,11 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 					// we're above genesis height, but are we on the best chain with genesis?
 					_, height, err := vm.TBCFullNode.BlockHeaderByHash(ctx.Context, &ghh)
 					if err != nil {
-						log.Crit(fmt.Sprintf("could not get block by hash: %s", err))
+						log.Crit("could not get block by hash", "error", err)
 					}
 
 					if height != genesisHeight {
-						log.Crit(fmt.Sprintf("mismatched genesis heights %d != %d", height, genesisHeight))
+						log.Crit("mismatched genesis heights", "height", height, "genesisHeight", genesisHeight)
 					}
 
 					break
@@ -337,7 +337,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			// this one
 			height, blockHeaderBest, err := vm.TBCFullNode.BlockHeaderBest(ctx.Context)
 			if err != nil {
-				log.Crit(fmt.Sprintf("error getting best block header: %s", err))
+				log.Crit("error getting best block header", "error", err)
 			}
 
 			for {
@@ -345,17 +345,17 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 				bhh := blockHeaderBest.BlockHash()
 				available, err := vm.TBCFullNode.FullBlockAvailable(ctx.Context, &bhh)
 				if err != nil {
-					log.Crit(fmt.Sprintf("could not determine if full block available: %s", err))
+					log.Crit("could not determine if full block available", "error", err)
 				}
 
 				// if it's not available, wait until it is
 				if !available {
-					log.Trace(fmt.Sprintf("block not available, will wait: %s:%d", blockHeaderBest.BlockHash().String(), height))
+					log.Trace("block not available, will wait", "hash", blockHeaderBest.BlockHash().String(), "height", height)
 					time.Sleep(5 * time.Second)
 					continue
 				}
 
-				log.Trace(fmt.Sprintf("block is available %s:%d", blockHeaderBest.BlockHash().String(), height))
+				log.Trace("block is available", "hash", blockHeaderBest.BlockHash().String(), "height", height)
 
 				log.Trace("done downloading blocks, now will sync indexers to best")
 
@@ -363,7 +363,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 				for {
 					missing, err := vm.TBCFullNode.BlocksMissing(ctx.Context, 100)
 					if err != nil {
-						log.Crit(fmt.Sprintf("could not get blocks missing: %s", err))
+						log.Crit("could not get blocks missing", "error", err)
 					}
 
 					if len(missing) == 0 {
@@ -372,10 +372,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 					// for each missing block, try to redownload
 					for _, m := range missing {
-						log.Trace(fmt.Sprintf("found missing block, will atttempt download: %s:%d", m.Hash, m.Height))
+						log.Trace("found missing block, will atttempt download", "hash", m.Hash, "height", m.Height)
 						_, err := vm.TBCFullNode.DownloadBlockFromRandomPeers(ctx.Context, m.Hash, 1)
 						if err != nil {
-							log.Crit(fmt.Sprintf("could not download block from random peer: %s", err))
+							log.Crit("could not download block from random peer", "error", err)
 						}
 					}
 
@@ -387,7 +387,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 				// to the known best block
 				bestBlockHash := blockHeaderBest.BlockHash()
 				if err := vm.TBCFullNode.SyncIndexersToHash(ctx.Context, &bestBlockHash); err != nil {
-					log.Crit(fmt.Sprintf("could not sync indexers to best: %s", err))
+					log.Crit("could not sync indexers to best", "error", err)
 				}
 
 				break

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -342,13 +342,24 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 			for {
 				bhh := blockHeaderBest.BlockHash()
-				avail, err := vm.TBCFullNode.FullBlockAvailable(ctx.Context, &bhh)
+				available, err := vm.TBCFullNode.FullBlockAvailable(ctx.Context, &bhh)
 				if err != nil {
 					log.Crit(fmt.Sprintf("could not determine if full block available: %s", err))
 				}
 
-				if !avail {
+				if !available {
 					log.Info(fmt.Sprintf("block not available, will wait: %s:%d", blockHeaderBest.BlockHash().String(), height))
+					time.Sleep(5 * time.Second)
+					continue
+				}
+
+				available, _, _, err = vm.TBCBlocksAvailableToHeader(ctx.Context, blockHeaderBest)
+				if err != nil {
+					log.Crit(fmt.Sprintf("error occurred checking if blocks available: %s", err))
+				}
+
+				if !available {
+					log.Info(fmt.Sprintf("block not available to header, will wait: %s:%d", blockHeaderBest.BlockHash().String(), height))
 					time.Sleep(5 * time.Second)
 					continue
 				}

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -297,8 +297,8 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 		for {
 
-			// wait until we have a high degree of confidence that we have
-			// chain up to the hvm genesis block indexed
+			// wait until we have a block header that is above hvm genesis height, then confirm we
+			// have hvm genesis block at the expected height
 			for {
 				select {
 				case <-time.After(1 * time.Second):
@@ -333,20 +333,22 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 			log.Info("done getting hvm genesis header, waiting until we have all of the blocks")
 
-			// wait until we have full blocks up to the best, this is a bit unsafe since we
-			// don't check every block, but we have a high degree of confidence we have full blocks
+			// grab the current best block, we will then wait until we have all full blocks up to
+			// this one
 			height, blockHeaderBest, err := vm.TBCFullNode.BlockHeaderBest(ctx.Context)
 			if err != nil {
 				log.Crit(fmt.Sprintf("error getting block header best: %s", err))
 			}
 
 			for {
+				// check if we have the full best block available
 				bhh := blockHeaderBest.BlockHash()
 				available, err := vm.TBCFullNode.FullBlockAvailable(ctx.Context, &bhh)
 				if err != nil {
 					log.Crit(fmt.Sprintf("could not determine if full block available: %s", err))
 				}
 
+				// if it's not available, wait until it is
 				if !available {
 					log.Info(fmt.Sprintf("block not available, will wait: %s:%d", blockHeaderBest.BlockHash().String(), height))
 					time.Sleep(5 * time.Second)
@@ -357,6 +359,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 				log.Info("done downloading blocks, now will sync indexers to best")
 
+				// wait until we have fixed all of the missing blocks
 				for {
 					missing, err := vm.TBCFullNode.BlocksMissing(ctx.Context, 100)
 					if err != nil {
@@ -367,6 +370,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 						break
 					}
 
+					// for each missing block, try to redownload
 					for _, m := range missing {
 						log.Info("found missing block, will atttempt download: %s:%d", m.Hash, m.Height)
 						_, err := vm.TBCFullNode.DownloadBlockFromRandomPeers(ctx.Context, m.Hash, 1)
@@ -374,8 +378,13 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 							log.Crit(fmt.Sprintf("could not download block from random peer: %s", err))
 						}
 					}
+
+					// give some time for the redownloading to occur
+					time.Sleep(5 * time.Second)
 				}
 
+				// now that we supposedly have no missing blocks, sync the indexers
+				// to the known best block
 				bestBlockHash := blockHeaderBest.BlockHash()
 				if err := vm.TBCFullNode.SyncIndexersToHash(ctx.Context, &bestBlockHash); err != nil {
 					log.Crit(fmt.Sprintf("could not sync indexers to best: %s", err))

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -353,9 +353,16 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 					continue
 				}
 
-				available, _, _, err = vm.TBCBlocksAvailableToHeader(ctx.Context, blockHeaderBest)
+				available, _, missing, err := vm.TBCBlocksAvailableToHeader(ctx.Context, blockHeaderBest)
 				if err != nil {
 					log.Crit(fmt.Sprintf("error occurred checking if blocks available: %s", err))
+				}
+
+				if len(missing) > 0 {
+					for _, m := range missing {
+						log.Info(fmt.Sprintf("refecting: %s", missing.BlockHash().String()))
+						vm.TBCAttemptBlockRefetch(ctx.Context, missing)
+					}
 				}
 
 				if !available {

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -353,15 +353,15 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 					continue
 				}
 
-				available, _, missing, err := vm.TBCBlocksAvailableToHeader(ctx.Context, blockHeaderBest)
+				available, missing, _, err := vm.TBCBlocksAvailableToHeader(ctx.Context, blockHeaderBest)
 				if err != nil {
 					log.Crit(fmt.Sprintf("error occurred checking if blocks available: %s", err))
 				}
 
-				if len(missing) > 0 {
-					for _, m := range missing {
+				if missing != nil {
+					for _, m := range *missing {
 						log.Info(fmt.Sprintf("refecting: %s", m.BlockHash().String()))
-						vm.TBCAttemptBlockRefetch(ctx.Context, m)
+						vm.TBCAttemptBlockRefetch(ctx.Context, &m)
 					}
 				}
 


### PR DESCRIPTION
remove special case for hvm genesis < height of 5000 (i.e. localnet)

wait for the following to happen explicitly:
* the best block header is above hvm genesis
* we have all blocks up to the best
* we sync indexers to best block