### PR TITLE
Make common ancestor between zero-hashes the genesis by definition to fix block availability check on initial startup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@
 name: "Docker"
 on:
   push:
-#    branches: [ "hemi" ]
+    branches: [ "hemi" ]
 
 concurrency:
   group: "docker-${{ github.workflow }}-${{ github.event.number || github.ref }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@
 name: "Docker"
 on:
   push:
-    branches: [ "hemi" ]
+#    branches: [ "hemi" ]
 
 concurrency:
   group: "docker-${{ github.workflow }}-${{ github.event.number || github.ref }}"

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -305,17 +305,6 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			log.Info(fmt.Sprintf("got best block header of %s",
 				bhb.BlockHash().String()))
 
-			if genesisHeight < 5000 {
-				time.Sleep(10 * time.Second)
-				log.Info("genesis height is less than 5000, brute-force sync to genesis header")
-				_bh := genesisHeader.BlockHash()
-				err = vm.TBCFullNode.SyncIndexersToHash(ctx.Context, &_bh)
-				if err != nil {
-					log.Crit(fmt.Sprintf("error occurred indexing to the hvm genesis header (%s): %s", genesisHeader.BlockHash().String(), err))
-				}
-
-			}
-
 			// Get the current indexer information and make sure both indexers are at the same height
 			syncInfo = *vm.GetTBCFullNodeSyncStatus()
 

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -143,6 +143,21 @@ func hashEquals(a chainhash.Hash, b chainhash.Hash) bool {
 //   - *chainhash.Hash The hash of the first block header encountered which was not found
 //   - bool Whether there is a fork/reorg
 func FindCommonAncestor(a *tbc.HashHeight, b *tbc.HashHeight) (*wire.BlockHeader, uint64, *chainhash.Hash, bool, error) {
+	emptyChainHash := &chainhash.Hash{}
+
+	// If either of the hashes are empty, then assume common ancestor is genesis
+	if a.Hash.IsEqual(emptyChainHash) || b.Hash.IsEqual(emptyChainHash) {
+		gh, err := TBCFullNode.BlockHeadersByHeight(context.Background(), 0)
+		if err != nil {
+			// Should always be able to find genesis
+			log.Crit("Unable to query TBC for the genesis block", "err", err)
+		}
+		if len(gh) != 1 {
+			log.Crit("Should be exactly one genesis header in TBC")
+		}
+		return gh[0], 0, nil, false, nil
+	}
+
 	if a.Hash.IsEqual(&b.Hash) {
 		header, height, err := TBCFullNode.BlockHeaderByHash(context.Background(), &a.Hash)
 		if err != nil {


### PR DESCRIPTION
On initial startup with an empty TBC data directory, the check for blocks available to the effective genesis header will fail because the indexers have not indexed through the genesis block yet.

Fixed by updating the FindCommonAncestor() method to fall-through to returning the genesis block as a common ancestor if either of the tips for comparison equal the zero-hash.