### PR TITLE
"Audit" the ctx changes in tbc calls 

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -231,7 +231,7 @@ func FindCommonAncestor(a *tbc.HashHeight, b *tbc.HashHeight) (*wire.BlockHeader
 func TBCIndexToHashHeight(targetHH *tbc.HashHeight) error {
 	log.Info("TBCIndexToHashHight called with target", "target", targetHH.String())
 	// Check for indexer desync and attempt to fix.
-	FixMismatchedIndexesIfRequired(context.Background())
+	FixMismatchedIndexesIfRequired(MainCtx)
 
 	targetHash := targetHH.Hash
 


### PR DESCRIPTION
Looked over all the relevant context changes. Only found one instance that I believe was overlooked. 

NOTE: all tests reliant on functions that got changed to allow a context to be passed **_are now broken_**, as no context is passed to them.