### PR TITLE
accounting for nil fields in encoding/decoding of stored receipts

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -55,6 +55,7 @@ const (
 	// NilDepositDataPlaceholder is a special value placed in DepositNonce and DepositReceiptVersion to indicate
 	// that the fields should be treated as nil but need to be filled to populate later fields
 	NilDepositDataPlaceholder = 0xFFFFFFFFFFFFFFFF
+	NilPoPPayoutDataPlaceholder = NilDepositDataPlaceholder
 )
 
 // Receipt represents the results of a transaction.
@@ -488,9 +489,11 @@ func (r *ReceiptForStorage) EncodeRLP(_w io.Writer) error {
 		w.WriteUint64(NilDepositDataPlaceholder)
 		w.WriteUint64(*r.PoPPayoutNonce)
 	}
+
 	if r.BtcAttributesDepositedNonce != nil {
 		// Write placeholders because decoding is untyped, so non-zero values are necessary to indicate
 		// fields should be treated as nil
+		w.WriteUint64(NilDepositDataPlaceholder)
 		w.WriteUint64(NilDepositDataPlaceholder)
 		w.WriteUint64(NilDepositDataPlaceholder)
 		w.WriteUint64(*r.BtcAttributesDepositedNonce)
@@ -555,13 +558,16 @@ func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 	r.CumulativeGasUsed = stored.CumulativeGasUsed
 	r.Logs = stored.Logs
 	r.Bloom = CreateBloom((*Receipt)(r))
-	if stored.DepositNonce != nil {
+
+	if stored.DepositNonce != nil && *stored.DepositNonce != NilDepositDataPlaceholder {
 		r.DepositNonce = stored.DepositNonce
 		r.DepositReceiptVersion = stored.DepositReceiptVersion
 	}
-	if stored.PoPPayoutNonce != nil {
+
+	if stored.PoPPayoutNonce != nil && *stored.PoPPayoutNonce != NilPoPPayoutDataPlaceholder {
 		r.PoPPayoutNonce = stored.PoPPayoutNonce
 	}
+
 	if stored.BtcAttributesDepositedNonce != nil {
 		r.BtcAttributesDepositedNonce = stored.BtcAttributesDepositedNonce
 	}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math/big"
 	"unsafe"
+	"math"
 
 	"github.com/ethereum/go-ethereum/log"
 
@@ -54,7 +55,7 @@ const (
 
 	// NilDepositDataPlaceholder is a special value placed in DepositNonce and DepositReceiptVersion to indicate
 	// that the fields should be treated as nil but need to be filled to populate later fields
-	NilDepositDataPlaceholder = 0xFFFFFFFFFFFFFFFF
+	NilDepositDataPlaceholder = math.MaxUint64
 	NilPoPPayoutDataPlaceholder = NilDepositDataPlaceholder
 )
 

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -482,21 +482,18 @@ func (r *ReceiptForStorage) EncodeRLP(_w io.Writer) error {
 		if r.DepositReceiptVersion != nil {
 			w.WriteUint64(*r.DepositReceiptVersion)
 		}
-	}
-	if r.PoPPayoutNonce != nil {
+	} else if r.PoPPayoutNonce != nil {
 		// Write placeholders because decoding is untyped, so non-zero values are necessary to indicate
 		// fields should be treated as nil
 		w.WriteUint64(NilDepositDataPlaceholder)
 		w.WriteUint64(NilDepositDataPlaceholder)
 		w.WriteUint64(*r.PoPPayoutNonce)
-	}
-
-	if r.BtcAttributesDepositedNonce != nil {
+	} else if r.BtcAttributesDepositedNonce != nil {
 		// Write placeholders because decoding is untyped, so non-zero values are necessary to indicate
 		// fields should be treated as nil
 		w.WriteUint64(NilDepositDataPlaceholder)
 		w.WriteUint64(NilDepositDataPlaceholder)
-		w.WriteUint64(NilDepositDataPlaceholder)
+		w.WriteUint64(NilPoPPayoutDataPlaceholder)
 		w.WriteUint64(*r.BtcAttributesDepositedNonce)
 	}
 	w.ListEnd(outerList)

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -196,6 +196,41 @@ var (
 		},
 		Type: PopPayoutTxType,
 	}
+	btcAttributesDepositedWithNoNonce = &Receipt{
+		Status:            ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		Logs: []*Log{
+			{
+				Address: common.BytesToAddress([]byte{0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+			{
+				Address: common.BytesToAddress([]byte{0x01, 0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+		},
+		Type: BtcAttributesDepositedTxType,
+	}
+	btcAttributesDepositedWithNonce = &Receipt{
+		Status:            ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		BtcAttributesDepositedNonce:    &nonce,
+		Logs: []*Log{
+			{
+				Address: common.BytesToAddress([]byte{0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+			{
+				Address: common.BytesToAddress([]byte{0x01, 0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+		},
+		Type: BtcAttributesDepositedTxType,
+	}
 
 	// Create a few transactions to have receipts for
 	to2 = common.HexToAddress("0x2")
@@ -1169,6 +1204,8 @@ func TestRoundTripReceipt(t *testing.T) {
 		{name: "DepositWithNonceAndVersion", rcpt: depositReceiptWithNonceAndVersion},
 		{name: "PoPPayoutNoNonce", rcpt: popPayoutReceiptNoNonce},
 		{name: "PoPPayoutWithNonce", rcpt: popPayoutReceiptWithNonce},
+		{name: "BtcAttributesDepositedWithNonce", rcpt: btcAttributesDepositedWithNonce},
+		{name: "BtcAttributesDepositedWithNoNonce", rcpt: btcAttributesDepositedWithNoNonce},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1208,6 +1245,8 @@ func TestRoundTripReceiptForStorage(t *testing.T) {
 		{name: "DepositWithNonceAndVersion", rcpt: depositReceiptWithNonceAndVersion},
 		{name: "PoPPayoutNoNonce", rcpt: popPayoutReceiptNoNonce},
 		{name: "PoPPayoutWithNonce", rcpt: popPayoutReceiptWithNonce},
+		{name: "BtcAttributesDepositedWithNonce", rcpt: btcAttributesDepositedWithNonce},
+		{name: "BtcAttributesDepositedWithNoNonce", rcpt: btcAttributesDepositedWithNoNonce},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
when we encode a nil uint64 field, we set it to a special value
(MaxUint64).  however, when we decode we were not checking if fields
were set to that.  so we would decode stored fields to the special
value.

now, check that when decoding