### PR TITLE
ensure that cmd/geth package is passing tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,3 +33,6 @@ jobs:
       # back in, one by one
       - name: "test core"
         run: go test -v ./core
+
+      - name: "test cmd/geth"
+        run: go test -v ./cmd/geth

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 debug:1.0 engine:1.0 eth:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 debug:1.0 engine:1.0 eth:1.0 kss:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0"
 	httpAPIs = "eth:1.0 net:1.0 rpc:1.0 web3:1.0"
 )
 
@@ -43,7 +43,7 @@ func runMinimalGeth(t *testing.T, args ...string) *testgeth {
 	// --syncmode=full to avoid allocating fast sync bloom
 	allArgs := []string{"--holesky", "--networkid", "1337", "--authrpc.port", "0", "--syncmode=full", "--port", "0",
 		"--nat", "none", "--nodiscover", "--maxpeers", "0", "--cache", "64",
-		"--datadir.minfreedisk", "0"}
+		"--datadir.minfreedisk", "0", "--hvm.enabled=0"}
 	return runGeth(t, append(allArgs, args...)...)
 }
 

--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -91,7 +91,7 @@ func TestCustomGenesis(t *testing.T) {
 		geth := runGeth(t, "--networkid", "1337", "--syncmode=full", "--cache", "16",
 			"--datadir", datadir, "--maxpeers", "0", "--port", "0", "--authrpc.port", "0",
 			"--nodiscover", "--nat", "none", "--ipcdisable",
-			"--exec", tt.query, "console")
+			"--exec", tt.query, "console",  "--hvm.enabled=0")
 		geth.ExpectRegexp(tt.result)
 		geth.ExpectExit()
 	}
@@ -143,7 +143,7 @@ func TestCustomBackend(t *testing.T) {
 			args := append(tt.execArgs, "--networkid", "1337", "--syncmode=full", "--cache", "16",
 				"--datadir", datadir, "--maxpeers", "0", "--port", "0", "--authrpc.port", "0",
 				"--nodiscover", "--nat", "none", "--ipcdisable",
-				"--exec", "eth.getBlock(0).nonce", "console")
+				"--exec", "eth.getBlock(0).nonce", "console", "--hvm.enabled=0")
 			geth := runGeth(t, args...)
 			geth.ExpectRegexp(tt.execExpect)
 			geth.ExpectExit()


### PR DESCRIPTION
* add --hvm.enabled=0 to cli tests to not start tbc
* added kss:1.0 to output
* added tests in CI