### PR TITLE
added extra logging around tx propagation

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -298,6 +298,9 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 		if b.disableTxPool {
 			return nil
 		}
+
+		log.Info("sending tx to txPool", "hash", signedTx.Hash())
+
 		// Retain tx in local tx pool after forwarding, for local RPC usage.
 		if err := b.eth.txPool.Add([]*types.Transaction{signedTx}, false)[0]; err != nil {
 			log.Warn("successfully sent tx to sequencer, but failed to persist in local tx pool", "err", err, "tx", signedTx.Hash())

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
@@ -78,6 +79,10 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 		return h.txFetcher.Notify(peer.ID(), packet.Types, packet.Sizes, packet.Hashes)
 
 	case *eth.TransactionsPacket:
+		for _, tx := range *packet {
+			log.Info("received transaction in packet from peer", "hash", tx.Hash(), "peer id", peer.ID)
+		}
+
 		for _, tx := range *packet {
 			if tx.Type() == types.BlobTxType {
 				return errors.New("disallowed broadcast blob transaction")

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -95,6 +95,10 @@ func (p *Peer) broadcastTransactions() {
 			if len(txs) > 0 {
 				done = make(chan struct{})
 				go func() {
+					for _, tx := range txs {
+						log.Info("sending tx to peer", "hash", tx.Hash().String(), "peer id", p.ID)
+					}
+
 					if err := p.SendTransactions(txs); err != nil {
 						fail <- err
 						return

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -138,6 +138,7 @@ func (p *Peer) markTransaction(hash common.Hash) {
 func (p *Peer) SendTransactions(txs types.Transactions) error {
 	// Mark all the transactions as known, but ensure we don't overflow our limits
 	for _, tx := range txs {
+		p.Log().Info("will send tx to peer", "hash", tx.Hash(), "peer id", p.ID)
 		p.knownTxs.Add(tx.Hash())
 	}
 	return p2p.Send(p.rw, TransactionsMsg, txs)
@@ -166,6 +167,9 @@ func (p *Peer) AsyncSendTransactions(hashes []common.Hash) {
 func (p *Peer) sendPooledTransactionHashes(hashes []common.Hash, types []byte, sizes []uint32) error {
 	// Mark all the transactions as known, but ensure we don't overflow our limits
 	p.knownTxs.Add(hashes...)
+	for _, hash := range hashes {
+		p.Log().Info("sending pooled tx to peer", "hash", hash, "peer id", p.ID)
+	}
 	return p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket{Types: types, Sizes: sizes, Hashes: hashes})
 }
 
@@ -186,6 +190,10 @@ func (p *Peer) AsyncSendPooledTransactionHashes(hashes []common.Hash) {
 func (p *Peer) ReplyPooledTransactionsRLP(id uint64, hashes []common.Hash, txs []rlp.RawValue) error {
 	// Mark all the transactions as known, but ensure we don't overflow our limits
 	p.knownTxs.Add(hashes...)
+
+	for _, hash := range hashes {
+		p.Log().Info("replying with pooled tx", "hash", hash, "peer id", p.ID)
+	}
 
 	// Not packed into PooledTransactionsResponse to avoid RLP decoding
 	return p2p.Send(p.rw, PooledTransactionsMsg, &PooledTransactionsRLPPacket{

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1667,16 +1667,21 @@ func (api *TransactionAPI) sign(addr common.Address, tx *types.Transaction) (*ty
 
 // SubmitTransaction is a helper function that submits tx to txPool and logs a message.
 func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (common.Hash, error) {
+	log.Info("received transaction for submission", "hash", tx.Hash().Hex())
 	// If the transaction fee cap is already specified, ensure the
 	// fee of the given transaction is _reasonable_.
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), b.RPCTxFeeCap()); err != nil {
+		log.Error("error checking txfee", "hash", tx.Hash().Hex(), "error", err)
 		return common.Hash{}, err
 	}
 	if !b.UnprotectedAllowed() && !tx.Protected() {
+		err := errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
+		log.Error("error checking protected txs", "hash", tx.Hash().Hex(), "error", err)
 		// Ensure only eip155 signed transactions are submitted if EIP155Required is set.
-		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
+		return common.Hash{}, err
 	}
 	if err := b.SendTx(ctx, tx); err != nil {
+		log.Error("error calling SendTx", "hash", tx.Hash().Hex(), "error", err)
 		return common.Hash{}, err
 	}
 	// Print a log with full tx details for manual investigations and interventions


### PR DESCRIPTION
added logging for:
* receiving a tx over rpc sendRawTransaction
* adding a tx to the txpool
* sending a tx via broadcast
  * logging hash+peerId combo
* responding to a tx request