### PR TITLE
fix: ignore contract precompiles, except for hvm, between prague and jovian

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -843,6 +843,7 @@ func init() {
 	for k := range PrecompiledContractsHvm0 {
 		PrecompiledAddressesHvm0 = append(PrecompiledAddressesHvm0, k)
 	}
+
 	for k := range PrecompiledContractsPrague {
 		PrecompiledAddressesPrague = append(PrecompiledAddressesPrague, k)
 	}
@@ -945,6 +946,9 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 
 	switch {
 	case rules.IsHvm0:
+		if rules.IsPrague && !rules.IsOptimismJovian {
+			return append([]common.Address{}, PrecompiledAddressesHvm0...)
+		}
 		return append(nonHvmPrecompiles, PrecompiledAddressesHvm0...)
 	default:
 		return nonHvmPrecompiles


### PR DESCRIPTION
prior, during the init() function call, a recent change in op-geth added precompiles that would be returned in ActivePrecompiles.  this affects gas prices.  since this hasn't been deployed yet, someone running op-geth and connecting to our network would have a mismatch gas calculation.

since we're not at jovian yet, explicitly ignore these precompiles in ActivePrecompiles until we reach the jovian fork (not yet determined).

fixes https://github.com/hemilabs/op-geth/issues/61