### PR TITLE
feat: added hemi btc block rpc calls

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 debug:1.0 engine:1.0 eth:1.0 kss:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 debug:1.0 engine:1.0 eth:1.0 hemi:1.0 kss:1.0 miner:1.0 net:1.0 rpc:1.0 txpool:1.0 web3:1.0"
 	httpAPIs = "eth:1.0 net:1.0 rpc:1.0 web3:1.0"
 )
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -23,6 +23,9 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -45,6 +48,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/hemilabs/heminetwork/database"
 	"github.com/hemilabs/heminetwork/hemi"
 )
 
@@ -56,6 +60,8 @@ type EthAPIBackend struct {
 	eth                 *Ethereum
 	gpo                 *gasprice.Oracle
 }
+
+var ErrTbcFullNodeNotInit = errors.New("tbc full node not init'd")
 
 // ChainConfig returns the active chain configuration.
 func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
@@ -551,4 +557,35 @@ func (b *EthAPIBackend) GetMostRecentKeystones(count uint) ([]hemi.L2Keystone, e
 
 func (b *EthAPIBackend) GetKeystoneAndDescendants(hash []byte, count uint) ([]hemi.L2Keystone, error) {
 	return b.eth.blockchain.GetKeystoneAndDescendants(hash, count)
+}
+
+func (b *EthAPIBackend) GetBtcBlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Block, error) {
+	if vm.TBCFullNode == nil {
+		return nil, ErrTbcFullNodeNotInit
+	}
+
+	block, err := vm.TBCFullNode.BlockByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	return block, nil
+}
+
+func (b *EthAPIBackend) GetBtcBlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*wire.BlockHeader, error) {
+	if vm.TBCFullNode == nil {
+		return nil, ErrTbcFullNodeNotInit
+	}
+
+	blockHeader, _, err := vm.TBCFullNode.BlockHeaderByHash(ctx, hash)
+	if err != nil {
+		// Clayton note:
+		// instead of the real error, we seem to be getting a *fmt.wrapError
+		// when querying for a hash that does not exists.  this is likely
+		// an issue with the BlockHeaderByHash function, though I am unsure
+		// this will work for now but needs to be investigated
+		return nil, database.ErrNotFound
+	}
+
+	return blockHeader, nil
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -23,7 +23,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/ethereum/go-ethereum"
@@ -559,7 +558,7 @@ func (b *EthAPIBackend) GetKeystoneAndDescendants(hash []byte, count uint) ([]he
 	return b.eth.blockchain.GetKeystoneAndDescendants(hash, count)
 }
 
-func (b *EthAPIBackend) GetBtcBlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Block, error) {
+func (b *EthAPIBackend) GetBtcBlockByHash(ctx context.Context, hash chainhash.Hash) (*wire.MsgBlock, error) {
 	if vm.TBCFullNode == nil {
 		return nil, ErrTbcFullNodeNotInit
 	}
@@ -569,7 +568,7 @@ func (b *EthAPIBackend) GetBtcBlockByHash(ctx context.Context, hash chainhash.Ha
 		return nil, err
 	}
 
-	return block, nil
+	return block.MsgBlock().Copy(), nil
 }
 
 func (b *EthAPIBackend) GetBtcBlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*wire.BlockHeader, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -581,7 +581,7 @@ func (b *EthAPIBackend) GetBtcBlockHeaderByHash(ctx context.Context, hash chainh
 		// Clayton note:
 		// instead of the real error, we seem to be getting a *fmt.wrapError
 		// when querying for a hash that does not exists.  this is likely
-		// an issue with the BlockHeaderByHash function, though I am unsure
+		// an issue with the BlockHeaderByHash function, though I am unsure.
 		// this will work for now but needs to be investigated
 		return nil, database.ErrNotFound
 	}

--- a/eth/api_hemi.go
+++ b/eth/api_hemi.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/ethereum/go-ethereum/log"
@@ -131,7 +130,7 @@ func (api *HemiAPI) NewKeystones(ctx context.Context) (*rpc.Subscription, error)
 	return rpcSub, nil
 }
 
-func (api *HemiAPI) GetBtcBlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.Block, error) {
+func (api *HemiAPI) GetBtcBlockByHash(ctx context.Context, hash *chainhash.Hash) (*wire.MsgBlock, error) {
 	block, err := api.e.APIBackend.GetBtcBlockByHash(ctx, *hash)
 	if err != nil {
 		return nil, err

--- a/eth/api_hemi.go
+++ b/eth/api_hemi.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/hex"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hemilabs/heminetwork/api/protocol"
@@ -127,4 +129,22 @@ func (api *HemiAPI) NewKeystones(ctx context.Context) (*rpc.Subscription, error)
 	}()
 
 	return rpcSub, nil
+}
+
+func (api *HemiAPI) GetBtcBlockByHash(ctx context.Context, hash *chainhash.Hash) (*btcutil.Block, error) {
+	block, err := api.e.APIBackend.GetBtcBlockByHash(ctx, *hash)
+	if err != nil {
+		return nil, err
+	}
+
+	return block, nil
+}
+
+func (api *HemiAPI) GetBtcBlockHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*wire.BlockHeader, error) {
+	blockHeader, err := api.e.APIBackend.GetBtcBlockHeaderByHash(ctx, *hash)
+	if err != nil {
+		return nil, err
+	}
+
+	return blockHeader, nil
 }

--- a/eth/api_hemi_test.go
+++ b/eth/api_hemi_test.go
@@ -1,0 +1,164 @@
+package eth
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/go-test/deep"
+	"github.com/hemilabs/heminetwork/database"
+	"github.com/hemilabs/heminetwork/service/tbc"
+)
+
+func TestGetBtcBlockByHash(t *testing.T) {
+	type testTableItem struct {
+		name          string
+		hash          chainhash.Hash
+		expectedError error
+		testNoInit    bool
+	}
+
+	fakeBitcoinBlockHash := chainhash.DoubleHashH([]byte("notreal"))
+	realBitcoinBlockHash := *chaincfg.RegressionNetParams.GenesisHash
+	realBitcoinBlock := chaincfg.RegressionNetParams.GenesisBlock
+
+	testTable := []testTableItem{
+		testTableItem{
+			name:          "btc block by hash not found",
+			hash:          fakeBitcoinBlockHash,
+			expectedError: database.BlockNotFoundError{fakeBitcoinBlockHash},
+		},
+		testTableItem{
+			name:          "btc block by hash found (regtest genesis)",
+			hash:          realBitcoinBlockHash,
+			expectedError: nil,
+		},
+		testTableItem{
+			name:          "tbc not init yet",
+			expectedError: ErrTbcFullNodeNotInit,
+			testNoInit:    true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			vm.TBCFullNode = nil
+			if !testCase.testNoInit {
+				tbcParentDir := os.TempDir()
+				tbcDir, err := ioutil.TempDir(tbcParentDir, testCase.name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.RemoveAll(tbcDir)
+
+				if err := vm.SetupTBCFullNode(t.Context(), &tbc.Config{
+					Network:     "localnet",
+					LevelDBHome: tbcDir,
+					Seeds:       []string{},
+				}); err != nil {
+					t.Fatalf("could not set up tbc full node: %s", err)
+				}
+
+				select {
+				case <-time.After(5 * time.Second):
+				case <-t.Context().Done():
+					t.Fatal(t.Context().Err())
+				}
+			}
+
+			backend := initBackend(true)
+
+			block, err := backend.GetBtcBlockByHash(t.Context(), testCase.hash)
+			if err != nil && testCase.expectedError == nil {
+				t.Fatalf("unexpected error: %s", err)
+			} else if err != nil && testCase.expectedError != nil {
+				if diff := deep.Equal(err, testCase.expectedError); len(diff) > 0 {
+					t.Fatalf("unexpected diff: %s", diff)
+				}
+			} else if testCase.expectedError == nil {
+				if diff := deep.Equal(btcutil.NewBlock(realBitcoinBlock), block); len(diff) > 0 {
+					t.Fatalf("unexpected diff: %s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestGetBtcBlockHeaderByHash(t *testing.T) {
+	type testTableItem struct {
+		name          string
+		hash          chainhash.Hash
+		expectedError error
+		testNoInit    bool
+	}
+
+	fakeBitcoinBlockHash := chainhash.DoubleHashH([]byte("notreal"))
+	realBitcoinBlockHash := *chaincfg.RegressionNetParams.GenesisHash
+	realBitcoinBlockHeader := chaincfg.RegressionNetParams.GenesisBlock.Header
+
+	testTable := []testTableItem{
+		testTableItem{
+			name:          "btc block by hash not found",
+			hash:          fakeBitcoinBlockHash,
+			expectedError: database.ErrNotFound,
+		},
+		testTableItem{
+			name:          "btc block by hash found (regtest genesis)",
+			hash:          realBitcoinBlockHash,
+			expectedError: nil,
+		},
+		testTableItem{
+			name:          "tbc not init yet",
+			expectedError: ErrTbcFullNodeNotInit,
+			testNoInit:    true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			vm.TBCFullNode = nil
+			if !testCase.testNoInit {
+				tbcParentDir := os.TempDir()
+				tbcDir, err := ioutil.TempDir(tbcParentDir, testCase.name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.RemoveAll(tbcDir)
+
+				if err := vm.SetupTBCFullNode(t.Context(), &tbc.Config{
+					Network:     "localnet",
+					LevelDBHome: tbcDir,
+					Seeds:       []string{},
+				}); err != nil {
+					t.Fatalf("could not set up tbc full node: %s", err)
+				}
+
+				select {
+				case <-time.After(5 * time.Second):
+				case <-t.Context().Done():
+					t.Fatal(t.Context().Err())
+				}
+			}
+
+			backend := initBackend(true)
+
+			blockHeader, err := backend.GetBtcBlockHeaderByHash(t.Context(), testCase.hash)
+			if err != nil && testCase.expectedError == nil {
+				t.Fatalf("unexpected error: %s", err)
+			} else if err != nil && testCase.expectedError != nil {
+				if diff := deep.Equal(err, testCase.expectedError); len(diff) > 0 {
+					t.Fatalf("unexpected diff: %s", diff)
+				}
+			} else if testCase.expectedError == nil {
+				if diff := deep.Equal(&realBitcoinBlockHeader, blockHeader); len(diff) > 0 {
+					t.Fatalf("unexpected diff: %s", diff)
+				}
+			}
+		})
+	}
+}

--- a/eth/api_hemi_test.go
+++ b/eth/api_hemi_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -81,7 +80,7 @@ func TestGetBtcBlockByHash(t *testing.T) {
 					t.Fatalf("unexpected diff: %s", diff)
 				}
 			} else if testCase.expectedError == nil {
-				if diff := deep.Equal(btcutil.NewBlock(realBitcoinBlock), block); len(diff) > 0 {
+				if diff := deep.Equal(realBitcoinBlock, block); len(diff) > 0 {
 					t.Fatalf("unexpected diff: %s", diff)
 				}
 			}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -552,8 +552,18 @@ func (s *Ethereum) APIs() []rpc.API {
 		}, {
 			Namespace: "net",
 			Service:   s.netRPCService,
-		}, {
+		},
+
+		// this is redundant, but we introduced hemi-specific calls into the
+		// "kss" namespace because we were only dealing with kss keystones at
+		// the time.  we can discuss, but I think that a better namespace would
+		// be "hemi", so make each do the same for now
+		{
 			Namespace: "kss",
+			Service:   NewHemiAPI(s),
+		},
+		{
+			Namespace: "hemi",
 			Service:   NewHemiAPI(s),
 		},
 	}...)

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -24,6 +24,9 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -250,6 +253,26 @@ func (ec *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.H
 		err = ethereum.NotFound
 	}
 	return head, err
+}
+
+func (ec *Client) GetBtcBlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Block, error) {
+	var block btcutil.Block
+	err := ec.c.CallContext(ctx, &block, "hemi_getBtcBlockByHash", hash.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return &block, nil
+}
+
+func (ec *Client) GetBtcBlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*wire.BlockHeader, error) {
+	var blockHeader wire.BlockHeader
+	err := ec.c.CallContext(ctx, &blockHeader, "hemi_getBtcBlockHeaderByHash", hash.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return &blockHeader, nil
 }
 
 type rpcTransaction struct {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/ethereum/go-ethereum"
@@ -255,14 +254,14 @@ func (ec *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.H
 	return head, err
 }
 
-func (ec *Client) GetBtcBlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Block, error) {
-	var block btcutil.Block
+func (ec *Client) GetBtcBlockByHash(ctx context.Context, hash chainhash.Hash) (*wire.MsgBlock, error) {
+	var block wire.MsgBlock
 	err := ec.c.CallContext(ctx, &block, "hemi_getBtcBlockByHash", hash.String())
 	if err != nil {
 		return nil, err
 	}
 
-	return &block, nil
+	return block.Copy(), nil
 }
 
 func (ec *Client) GetBtcBlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*wire.BlockHeader, error) {

--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -52,6 +52,7 @@ type Client interface {
 	ethereum.TransactionReader
 	ethereum.TransactionSender
 	ethereum.ChainIDReader
+	ethereum.BtcChainReader
 }
 
 // simClient wraps ethclient. This exists to prevent extracting ethclient.Client

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -389,7 +389,7 @@ func TestHemiAPIGetBtcBlockByHash(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				defer os.RemoveAll(tbcParentDir)
+				defer os.RemoveAll(tbcDir)
 
 				if err := vm.SetupTBCFullNode(t.Context(), &tbc.Config{
 					Network:     "localnet",
@@ -466,7 +466,7 @@ func TestHemiAPIGetBtcBlockHeaderByHash(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				defer os.RemoveAll(tbcParentDir)
+				defer os.RemoveAll(tbcDir)
 
 				if err := vm.SetupTBCFullNode(t.Context(), &tbc.Config{
 					Network:     "localnet",

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -20,17 +20,27 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
+	"io/ioutil"
 	"math/big"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/go-test/deep"
+	"github.com/hemilabs/heminetwork/database"
+	"github.com/hemilabs/heminetwork/service/tbc"
 	"github.com/holiman/uint256"
 	"go.uber.org/goleak"
 )
@@ -337,6 +347,159 @@ func TestAdjustTimeAfterFork(t *testing.T) {
 	head, _ := client.HeaderByNumber(ctx, nil)
 	if head.Number.Uint64() == 2 && head.ParentHash != h1.Hash() {
 		t.Errorf("failed to build block on fork")
+	}
+}
+
+func TestHemiAPIGetBtcBlockByHash(t *testing.T) {
+	type testTableItem struct {
+		name          string
+		hash          chainhash.Hash
+		expectedError error
+		testNoInit    bool
+	}
+
+	fakeBitcoinBlockHash := chainhash.DoubleHashH([]byte("notreal"))
+	realBitcoinBlockHash := *chaincfg.RegressionNetParams.GenesisHash
+	realBitcoinBlock := chaincfg.RegressionNetParams.GenesisBlock
+
+	testTable := []testTableItem{
+		testTableItem{
+			name:          "btc block by hash not found",
+			hash:          fakeBitcoinBlockHash,
+			expectedError: database.BlockNotFoundError{fakeBitcoinBlockHash},
+		},
+		testTableItem{
+			name:          "btc block by hash found (regtest genesis)",
+			hash:          realBitcoinBlockHash,
+			expectedError: nil,
+		},
+		testTableItem{
+			name:          "tbc not init yet",
+			expectedError: eth.ErrTbcFullNodeNotInit,
+			testNoInit:    true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			vm.TBCFullNode = nil
+			if !testCase.testNoInit {
+				tbcParentDir := os.TempDir()
+				tbcDir, err := ioutil.TempDir(tbcParentDir, testCase.name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.RemoveAll(tbcParentDir)
+
+				if err := vm.SetupTBCFullNode(t.Context(), &tbc.Config{
+					Network:     "localnet",
+					LevelDBHome: tbcDir,
+					Seeds:       []string{},
+				}); err != nil {
+					t.Fatalf("could not set up tbc full node: %s", err)
+				}
+
+				select {
+				case <-time.After(5 * time.Second):
+				case <-t.Context().Done():
+					t.Fatal(t.Context().Err())
+				}
+			}
+
+			sim := NewBackend(types.GenesisAlloc{})
+			defer sim.Close()
+
+			client := sim.Client()
+			block, err := client.GetBtcBlockByHash(context.Background(), testCase.hash)
+			if err != nil && testCase.expectedError == nil {
+				t.Fatalf("unexpected error: %s", err)
+			} else if err != nil && testCase.expectedError != nil {
+				if diff := deep.Equal(err.Error(), testCase.expectedError.Error()); len(diff) > 0 {
+					t.Fatalf("unexpected diff: %s", diff)
+				}
+			} else if testCase.expectedError == nil {
+				if diff := deep.Equal(btcutil.NewBlock(realBitcoinBlock), block); len(diff) > 0 {
+					t.Fatalf("unexpected diff: %s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestHemiAPIGetBtcBlockHeaderByHash(t *testing.T) {
+	type testTableItem struct {
+		name          string
+		hash          chainhash.Hash
+		expectedError error
+		testNoInit    bool
+	}
+
+	fakeBitcoinBlockHash := chainhash.DoubleHashH([]byte("notreal"))
+	realBitcoinBlockHash := *chaincfg.RegressionNetParams.GenesisHash
+	realBitcoinBlock := chaincfg.RegressionNetParams.GenesisBlock
+	realBitcoinBlockHeader := realBitcoinBlock.Header
+
+	testTable := []testTableItem{
+		testTableItem{
+			name:          "btc block header by hash not found",
+			hash:          fakeBitcoinBlockHash,
+			expectedError: database.ErrNotFound,
+		},
+		testTableItem{
+			name:          "btc block header by hash found (regtest genesis)",
+			hash:          realBitcoinBlockHash,
+			expectedError: nil,
+		},
+		testTableItem{
+			name:          "tbc not init yet",
+			expectedError: eth.ErrTbcFullNodeNotInit,
+			testNoInit:    true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			vm.TBCFullNode = nil
+			if !testCase.testNoInit {
+				tbcParentDir := os.TempDir()
+				tbcDir, err := ioutil.TempDir(tbcParentDir, testCase.name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.RemoveAll(tbcParentDir)
+
+				if err := vm.SetupTBCFullNode(t.Context(), &tbc.Config{
+					Network:     "localnet",
+					LevelDBHome: tbcDir,
+					Seeds:       []string{},
+				}); err != nil {
+					t.Fatalf("could not set up tbc full node: %s", err)
+				}
+
+				select {
+				case <-time.After(5 * time.Second):
+				case <-t.Context().Done():
+					t.Fatal(t.Context().Err())
+				}
+			}
+
+			sim := NewBackend(types.GenesisAlloc{})
+			defer sim.Close()
+
+			client := sim.Client()
+			blockHeader, err := client.GetBtcBlockHeaderByHash(context.Background(), testCase.hash)
+			if err != nil && testCase.expectedError == nil {
+				t.Fatalf("unexpected error: %s", err)
+			} else if err != nil && testCase.expectedError != nil {
+				if diff := deep.Equal(err.Error(), testCase.expectedError.Error()); len(diff) > 0 {
+					t.Fatalf("unexpected diff: %s", diff)
+				}
+			} else if testCase.expectedError == nil {
+				if diff := deep.Equal(&realBitcoinBlockHeader, blockHeader); len(diff) > 0 {
+					t.Fatalf("unexpected diff: %s", diff)
+				}
+			}
+		})
 	}
 }
 

--- a/ethclient/simulated/backend_test.go
+++ b/ethclient/simulated/backend_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -418,7 +417,7 @@ func TestHemiAPIGetBtcBlockByHash(t *testing.T) {
 					t.Fatalf("unexpected diff: %s", diff)
 				}
 			} else if testCase.expectedError == nil {
-				if diff := deep.Equal(btcutil.NewBlock(realBitcoinBlock), block); len(diff) > 0 {
+				if diff := deep.Equal(realBitcoinBlock, block); len(diff) > 0 {
 					t.Fatalf("unexpected diff: %s", diff)
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/fjl/gencodec v0.1.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
+	github.com/go-test/deep v1.1.1
 	github.com/gofrs/flock v0.12.1
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb

--- a/interfaces.go
+++ b/interfaces.go
@@ -22,6 +22,9 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -280,4 +283,9 @@ type BlockNumberReader interface {
 // ChainIDReader provides access to the chain ID.
 type ChainIDReader interface {
 	ChainID(ctx context.Context) (*big.Int, error)
+}
+
+type BtcChainReader interface {
+	GetBtcBlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Block, error)
+	GetBtcBlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*wire.BlockHeader, error)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/ethereum/go-ethereum/common"
@@ -286,6 +285,6 @@ type ChainIDReader interface {
 }
 
 type BtcChainReader interface {
-	GetBtcBlockByHash(ctx context.Context, hash chainhash.Hash) (*btcutil.Block, error)
+	GetBtcBlockByHash(ctx context.Context, hash chainhash.Hash) (*wire.MsgBlock, error)
 	GetBtcBlockHeaderByHash(ctx context.Context, hash chainhash.Hash) (*wire.BlockHeader, error)
 }


### PR DESCRIPTION
added two new endpoints:
* hemi_getBtcBlockByHash
* hemi_getBtcBlockHeaderByHash

added tests

fixes https://github.com/hemilabs/op-geth/issues/68


examples:

```shell
curl http://localhost:18546   -X POST   -H "Content-Type: application/json"   --data '{"id": 1, "jsonrpc": "2.0", "method": "hemi_getBtcBlockByHash", "params": ["0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"]}'

{"jsonrpc":"2.0","id":1,"result":{"Header":{"Version":1,"PrevBlock":"0000000000000000000000000000000000000000000000000000000000000000","MerkleRoot":"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b","Timestamp":"2011-02-02T23:16:42Z","Bits":545259519,"Nonce":2},"Transactions":[{"Version":1,"TxIn":[{"PreviousOutPoint":{"Hash":"0000000000000000000000000000000000000000000000000000000000000000","Index":4294967295},"SignatureScript":"BP//AB0BBEVUaGUgVGltZXMgMDMvSmFuLzIwMDkgQ2hhbmNlbGxvciBvbiBicmluayBvZiBzZWNvbmQgYmFpbG91dCBmb3IgYmFua3M=","Witness":null,"Sequence":4294967295}],"TxOut":[{"Value":5000000000,"PkScript":"QQRniv2w/lVIJxln8aZxMLcQXNaoKOA5CaZ5YuDqH2Hetkn2vD9M7zjE81UE5R7BEt5cOE33uguNV4pMcCtr8R1frA=="}],"LockTime":0}]}}
```

```shell
curl http://localhost:18546   -X POST   -H "Content-Type: application/json"   --data '{"id": 1, "jsonrpc": "2.0", "method": "hemi_getBtcBlockHeaderByHash", "params": ["0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"]}'

{"jsonrpc":"2.0","id":1,"result":{"Version":1,"PrevBlock":"0000000000000000000000000000000000000000000000000000000000000000","MerkleRoot":"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b","Timestamp":"2011-02-02T23:16:42Z","Bits":545259519,"Nonce":2}}
```