### PR TITLE
TBCBlocksAvailableToHeader logging to trace level

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -463,7 +463,7 @@ func TBCBlocksAvailableToHeader(ctx context.Context, endingHeader *wire.BlockHea
 
 	missingFullBlocks := make([]wire.BlockHeader, 0)
 
-	log.Info(fmt.Sprintf("TBCBlocksAvailableToHeader called with endingHeader=%s, UTXOs synced to: "+
+	log.Trace(fmt.Sprintf("TBCBlocksAvailableToHeader called with endingHeader=%s, UTXOs synced to: "+
 		"%s and Txs synced to: %s", endingHeader.BlockHash().String(), utxoSync.Hash.String(), txSync.Hash.String()))
 
 	// When both indexers are at the same header, this will be that header.

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -463,8 +463,11 @@ func TBCBlocksAvailableToHeader(ctx context.Context, endingHeader *wire.BlockHea
 
 	missingFullBlocks := make([]wire.BlockHeader, 0)
 
-	log.Trace(fmt.Sprintf("TBCBlocksAvailableToHeader called with endingHeader=%s, UTXOs synced to: "+
-		"%s and Txs synced to: %s", endingHeader.BlockHash().String(), utxoSync.Hash.String(), txSync.Hash.String()))
+	log.Trace("TBCBlocksAvailableToHeader called with",
+		"endingHeader", endingHeader.BlockHash().String(),
+		"UTXOS Synced to", utxoSync.Hash.String(),
+		"Txs synced to", txSync.Hash.String(),
+	)
 
 	// When both indexers are at the same header, this will be that header.
 	// If the indexers are at different positions, this will be the common


### PR DESCRIPTION
Changed TBCBlocksAvailableToHeader log to be trace level, this is quite noisy and I don't think is needed unless debugging this specific part.