### PR TITLE
Revert "fix: ignore contract precompiles, except for hvm, between prague and jovian"

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -849,24 +849,6 @@ func init() {
 	for k := range PrecompiledContractsHvm0 {
 		PrecompiledAddressesHvm0 = append(PrecompiledAddressesHvm0, k)
 	}
-	for k := range PrecompiledContractsPrague {
-		PrecompiledAddressesPrague = append(PrecompiledAddressesPrague, k)
-	}
-	for k := range PrecompiledContractsOsaka {
-		PrecompiledAddressesOsaka = append(PrecompiledAddressesOsaka, k)
-	}
-	for k := range PrecompiledContractsFjord {
-		PrecompiledAddressesFjord = append(PrecompiledAddressesFjord, k)
-	}
-	for k := range PrecompiledContractsGranite {
-		PrecompiledAddressesGranite = append(PrecompiledAddressesGranite, k)
-	}
-	for k := range PrecompiledContractsIsthmus {
-		PrecompiledAddressesIsthmus = append(PrecompiledAddressesIsthmus, k)
-	}
-	for k := range PrecompiledContractsJovian {
-		PrecompiledAddressesJovian = append(PrecompiledAddressesJovian, k)
-	}
 }
 
 func activePrecompiledContracts(rules params.Rules) PrecompiledContracts {

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -849,7 +849,6 @@ func init() {
 	for k := range PrecompiledContractsHvm0 {
 		PrecompiledAddressesHvm0 = append(PrecompiledAddressesHvm0, k)
 	}
-
 	for k := range PrecompiledContractsPrague {
 		PrecompiledAddressesPrague = append(PrecompiledAddressesPrague, k)
 	}
@@ -952,9 +951,6 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 
 	switch {
 	case rules.IsHvm0:
-		if rules.IsPrague && !rules.IsOptimismJovian {
-			return append([]common.Address{}, PrecompiledAddressesHvm0...)
-		}
 		return append(nonHvmPrecompiles, PrecompiledAddressesHvm0...)
 	default:
 		return nonHvmPrecompiles


### PR DESCRIPTION
Reverts hemilabs/op-geth#62