### PR TITLE
fix: force eth protocol version ETH/68

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -386,7 +386,7 @@ func doTest(cmdline []string) {
 	gotest.Args = append(gotest.Args, "-tags=ckzg")
 
 	// Enable integration-tests
-	gotest.Args = append(gotest.Args, "-tags=integrationtests")
+	gotest.Args = append(gotest.Args, "-tags=integrationtests,eth_test")
 
 	// Test a single package at a time. CI builders are slow
 	// and some tests run into timeouts under load.

--- a/cmd/devp2p/internal/ethtest/protocol.go
+++ b/cmd/devp2p/internal/ethtest/protocol.go
@@ -32,7 +32,7 @@ const (
 // Unexported devp2p protocol lengths from p2p package.
 const (
 	baseProtoLen = 16
-	ethProtoLen  = 18
+	ethProtoLen  = 20
 	snapProtoLen = 8
 )
 

--- a/eth/protocols/eth/eth_protocol.go
+++ b/eth/protocols/eth/eth_protocol.go
@@ -1,0 +1,6 @@
+//go:build eth_test
+package eth
+
+// ProtocolVersions are the supported versions of the `eth` protocol (first
+// is primary).
+var ProtocolVersions = []uint{ETH69, ETH68}

--- a/eth/protocols/eth/hemi_protocol.go
+++ b/eth/protocols/eth/hemi_protocol.go
@@ -1,0 +1,6 @@
+//go:build !eth_test
+package eth
+
+// ProtocolVersions are the supported versions of the `eth` protocol (first
+// is primary) for Hemi.  Hemi only supports ETH68 at this time.
+var ProtocolVersions = []uint{ETH68}

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -38,13 +38,9 @@ const (
 // devp2p capability negotiation.
 const ProtocolName = "eth"
 
-// ProtocolVersions are the supported versions of the `eth` protocol (first
-// is primary).
-var ProtocolVersions = []uint{ETH69, ETH68}
-
 // protocolLengths are the number of implemented message corresponding to
 // different protocol versions.
-var protocolLengths = map[uint]uint64{ETH68: 19, ETH69: 18}
+var protocolLengths = map[uint]uint64{ETH68: 19, ETH69: 20}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 10 * 1024 * 1024
@@ -65,7 +61,7 @@ const (
 	ReceiptsMsg                   = 0x10
 	GetBtcBlocksMsg               = 0x11
 	BtcBlocksMsg                  = 0x12
-	BlockRangeUpdateMsg           = 0x11
+	BlockRangeUpdateMsg           = 0x13
 )
 
 var (


### PR DESCRIPTION

* update BlockRangeUpdateMsg to 0x13 so it doesn't clash with existing messages
* force protocol to ETH/68 to avoid other peers clashing, as BlockRangeUpdateMsg is only used in ETH/69
  * for tests, we use the eth_test tag to include ETH/69 in compilation, if that's omitted then only ETH/68 is used
* update protocol lengths to account for extra message types