### PR TITLE
fix: upon finding a bitcoin attributes deposited tx, ensure that we have it and all of its ancestors

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/hemilabs/heminetwork/cmd/btctool/bdf"
 	"github.com/hemilabs/heminetwork/service/tbc"
 	"github.com/holiman/uint256"
@@ -513,6 +514,36 @@ func New(stack *node.Node, config *ethconfig.Config, ctx context.Context) (*Ethe
 	eth.shutdownTracker.MarkStartup()
 
 	return eth, nil
+}
+
+func (e *Ethereum) SendRequestForHashToAllPeers(hash common.Hash) {
+	log.Trace("BTC block not found in TBC, making peer requests for block", "hash", hash)
+
+	for _, peer := range e.handler.peers.all() {
+		if err := peer.RequestBtcBlocks([]common.Hash{hash}); err != nil {
+			log.Error("Failed to request BTC block from peer", "peer", peer.ID(), "hash", hash, "err", err)
+		}
+	}
+}
+
+func (e *Ethereum) RequestBitcoinBlocksFromPeers(hash common.Hash) bool {
+	var ch chainhash.Hash
+	if err := ch.SetBytes(hash.Bytes()); err != nil {
+		// should not happen, fail loudly if it does
+		log.Crit("Failed to convert hash for TBC lookup", "hash", hash, "err", err)
+	}
+	available, err := vm.TBCFullNode.FullBlockAvailable(vm.MainCtx, ch)
+	if err != nil {
+		// also should not happen, fail loudly if it does
+		log.Crit("Failed to check BTC block availability before peer request", "hash", hash, "err", err)
+	} else if available {
+		log.Trace("BTC block already in TBC, skipping peer request", "hash", hash)
+		return true
+	}
+
+	go e.SendRequestForHashToAllPeers(hash)
+
+	return false
 }
 
 func makeExtraData(extra []byte) []byte {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -475,6 +475,41 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 				return engine.STATUS_INVALID, fmt.Errorf("transaction %d is not valid: %v", i, err)
 			}
 			transactions = append(transactions, &tx)
+
+			hashesToRequest := []common.Hash{}
+
+			if tx.Type() == types.BtcAttributesDepositedTxType {
+				var btcDepData types.BtcAttributesDepositData
+				if err := btcDepData.UnmarshalBinary(tx.Data()); err != nil {
+					return engine.STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("invalid canonical tip BtcAttributesDepositData"))
+				} else {
+					canonicalTip := common.Hash(btcDepData.CanonicalTip)
+					log.Trace("Requesting Bitcoin block from peers", "hash", canonicalTip)
+					hashesToRequest = append(hashesToRequest, canonicalTip)
+					for _, headerBytes := range btcDepData.Headers {
+						var blockHeader wire.BlockHeader
+						if err := blockHeader.Deserialize(bytes.NewReader(headerBytes[:])); err != nil {
+							return engine.STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("invalid headers in BtcAttributesDepositData"))
+						}
+						blockHash := common.Hash(blockHeader.BlockHash())
+						log.Trace("Requesting Bitcoin block from peers (from header)", "hash", blockHash)
+						hashesToRequest = append(hashesToRequest, blockHash)
+					}
+				}
+			}
+
+			retryNeeded := false
+			for _, hash := range hashesToRequest {
+				alreadyKnown := api.eth.RequestBitcoinBlocksFromPeers(hash)
+				if !alreadyKnown {
+					retryNeeded = true
+				}
+			}
+
+			if retryNeeded {
+				return engine.STATUS_INVALID, engine.GenericServerError.With(errors.New("missing blocks in forkchoiceupdated, will try to fetch"))
+			}
+
 		}
 		args := &miner.BuildPayloadArgs{
 			Parent:        update.HeadBlockHash,

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -472,9 +472,37 @@ func handleBTCBlocks(backend Backend, msg Decoder, peer *Peer) error {
 		}
 
 		log.Info("Added BTC block from geth P2P to TBC", "block", hash.String(), "height", insert)
+		go requestMissingAncestors(peer, &msgBlock.Header)
 	}
 
 	return nil
+}
+
+func requestMissingAncestors(peer *Peer, parentHash *wire.BlockHeader) {
+	_, blocksMissing, _, err := vm.TBCBlocksAvailableToHeader(vm.MainCtx, parentHash)
+	if err != nil {
+		log.Error("Failed to check BTC ancestor availability", "hash", parentHash.BlockHash().String(), "err", err)
+		return
+	}
+
+	if blocksMissing == nil || len(*blocksMissing) == 0 {
+		return
+	}
+
+	log.Info("Requesting missing BTC ancestor blocks from peer", "count", len(*blocksMissing), "peer", peer.ID())
+
+	// request each block missing in its own request.  I don't know how large
+	// blocksMissing will be, so I don't want to request all at once.
+	// we could "batch" the requests, but that's not as readable as this for
+	// loop
+	for _, bm := range *blocksMissing {
+		log.Info("requesting missing block from peer", "hash", common.Hash(bm.BlockHash()), "peer", peer.ID())
+		if err := peer.RequestBtcBlocks([]common.Hash{
+			common.Hash(bm.BlockHash()),
+		}); err != nil {
+			log.Error("could not request btc blocks from peer: %s", err)
+		}
+	}
 }
 
 func handleBlockHeaders(backend Backend, msg Decoder, peer *Peer) error {


### PR DESCRIPTION

* when forkChoiceUpdated is called, check the payload attributes for bitcoin attributes deposited transactions
* ensure that we have the headers and canonical tip stored in the aforementioned bitcoin attributes deposited transaction, otherwise request it from peers
* upon receiving a bitcoin block from peers via p2p, ensure that we have all ancestors

fixes https://github.com/hemilabs/op-geth/issues/79