### PR TITLE
fix: data race with prefetchBTCBlocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all:
 
 #? test: Run the tests.
 test: all
-	$(GORUN) build/ci.go test
+	$(GORUN) build/ci.go test -v
 
 #? lint: Run certain pre-selected linters.
 lint: ## Run linters.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1955,6 +1955,9 @@ func (bc *BlockChain) applyHvmHeaderConsensusUpdate(header *types.Header, attemp
 }
 
 func (bc *BlockChain) GetMissingBtcBlocks() []common.Hash {
+	bc.chainmu.Lock()
+	defer bc.chainmu.Unlock()
+
 	if bc == nil || bc.tbcHeaderNode == nil {
 		log.Warn("GetMissingBtcBlocks() does not have tbcHeaderNode active yet")
 		return nil

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -217,7 +217,9 @@ func (payload *Payload) ResolveFull() *engine.ExecutionPayloadEnvelope {
 func (payload *Payload) WaitFull() {
 	payload.lock.Lock()
 	defer payload.lock.Unlock()
-	payload.cond.Wait()
+	for payload.full == nil {
+		payload.cond.Wait()
+	}
 }
 
 func (payload *Payload) resolve(onlyFull bool) *engine.ExecutionPayloadEnvelope {


### PR DESCRIPTION
```
=== RUN   TestTrickRemoteBlockCache
==================
WARNING: DATA RACE
Read at 0x00c0002d9cb8 by goroutine 54525:
  github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).prefetchBTCBlocks()
      /Users/claytonnorthey/lima/workspace/op-geth/eth/protocols/eth/broadcast.go:46 +0x105
  github.com/ethereum/go-ethereum/eth/protocols/eth.NewPeer.gowrap2()
      /Users/claytonnorthey/lima/workspace/op-geth/eth/protocols/eth/peer.go:90 +0x2e

Previous write at 0x00c0002d9cb8 by goroutine 54520:
  github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).setBlockChain()
      /Users/claytonnorthey/lima/workspace/op-geth/eth/protocols/eth/peer.go:98 +0xde
  github.com/ethereum/go-ethereum/eth/protocols/eth.MakeProtocols.func1()
      /Users/claytonnorthey/lima/workspace/op-geth/eth/protocols/eth/handler.go:125 +0xae
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
      /Users/claytonnorthey/lima/workspace/op-geth/p2p/peer.go:484 +0xf3

Goroutine 54525 (running) created at:
  github.com/ethereum/go-ethereum/eth/protocols/eth.NewPeer()
      /Users/claytonnorthey/lima/workspace/op-geth/eth/protocols/eth/peer.go:90 +0x76a
  github.com/ethereum/go-ethereum/eth/protocols/eth.MakeProtocols.func1()
      /Users/claytonnorthey/lima/workspace/op-geth/eth/protocols/eth/handler.go:124 +0xa5
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
      /Users/claytonnorthey/lima/workspace/op-geth/p2p/peer.go:484 +0xf3

Goroutine 54520 (running) created at:
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols()
      /Users/claytonnorthey/lima/workspace/op-geth/p2p/peer.go:482 +0xfd
  github.com/ethereum/go-ethereum/p2p.(*Peer).run()
      /Users/claytonnorthey/lima/workspace/op-geth/p2p/peer.go:294 +0x289
  github.com/ethereum/go-ethereum/p2p.(*Server).runPeer()
      /Users/claytonnorthey/lima/workspace/op-geth/p2p/server.go:995 +0x369
  github.com/ethereum/go-ethereum/p2p.(*Server).launchPeer.gowrap1()
      /Users/claytonnorthey/lima/workspace/op-geth/p2p/server.go:978 +0x38
==================
```

fixes https://github.com/hemilabs/op-geth/issues/81