### PR TITLE
fix: cond.Wait() does not check condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all:
 
 #? test: Run the tests.
 test: all
-	$(GORUN) build/ci.go test
+	$(GORUN) build/ci.go test -v
 
 #? lint: Run certain pre-selected linters.
 lint: ## Run linters.

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -43,6 +43,7 @@ func (p *Peer) prefetchBTCBlocks() {
 	for {
 		select {
 		case <-time.After(5 * time.Second):
+			p.lock.Lock()
 			missingBlocks := p.blockchain.GetMissingBtcBlocks()
 			if missingBlocks != nil && len(missingBlocks) > 0 {
 				log.Info("Requesting missing BTC blocks from peer", "len", len(missingBlocks))
@@ -50,10 +51,11 @@ func (p *Peer) prefetchBTCBlocks() {
 				if err != nil {
 					// TODO: Change to Debug logging
 					log.Info("Error requesting BTC blocks from peer", "err", err)
+					p.lock.Unlock()
 					continue
 				}
 			}
-
+			p.lock.Unlock()
 		case <-p.term:
 			return
 		}

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -95,6 +95,9 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool) *Pe
 }
 
 func (p *Peer) setBlockChain(b *core.BlockChain) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	
 	p.blockchain = b
 }
 

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -217,15 +217,17 @@ func (payload *Payload) ResolveFull() *engine.ExecutionPayloadEnvelope {
 func (payload *Payload) WaitFull() {
 	payload.lock.Lock()
 	defer payload.lock.Unlock()
-	for payload.full == nil {
-		select {
-		case <-payload.rpcCtx.Done():
-			return
-		default:
-		}
 
-		payload.cond.Wait()
+	// if the payload stops building, we need to exit to avoid infinite
+	// waiting
+	select {
+	case <-payload.stop:
+		log.Warn("WaitFull() exiting; payload was stopped")
+		return
+	default:
 	}
+
+	payload.cond.Wait()
 }
 
 func (payload *Payload) resolve(onlyFull bool) *engine.ExecutionPayloadEnvelope {

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -217,7 +217,15 @@ func (payload *Payload) ResolveFull() *engine.ExecutionPayloadEnvelope {
 func (payload *Payload) WaitFull() {
 	payload.lock.Lock()
 	defer payload.lock.Unlock()
-	payload.cond.Wait()
+	for payload.full == nil {
+		select {
+		case <-payload.rpcCtx.Done():
+			return
+		default:
+		}
+
+		payload.cond.Wait()
+	}
 }
 
 func (payload *Payload) resolve(onlyFull bool) *engine.ExecutionPayloadEnvelope {


### PR DESCRIPTION
According to documentation here https://pkg.go.dev/sync#Cond.Wait :
> Because c.L is not locked while Wait is waiting, the caller typically cannot assume that the condition is true when Wait returns. Instead, the caller should Wait in a loop:

However, when we use cond.Wait() we do not check that the condition that is being waited for is true (i.e. full != nil) after Wait() returns.  There's a chance that .Wait() will return without the condition being true, thus progressing prematurely.

Add a condition around wait for it to be true via a nil check on full.

fixes #81