### PR TITLE
fix: request blocks from peers during snap sync

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -147,6 +147,24 @@ func SetupTBCFullNode(ctx context.Context, cfg *tbc.Config) error {
 	return nil
 }
 
+func BlockAvailableByCommonHash(hash common.Hash) bool {
+	var ch chainhash.Hash
+	if err := ch.SetBytes(hash.Bytes()); err != nil {
+		// should not happen, fail loudly if it does
+		log.Crit("Failed to convert hash for TBC lookup", "hash", hash, "err", err)
+	}
+	available, err := TBCFullNode.FullBlockAvailable(MainCtx, ch)
+	if err != nil {
+		// also should not happen, fail loudly if it does
+		log.Crit("Failed to check BTC block availability before peer request", "hash", hash, "err", err)
+	} else if available {
+		log.Trace("BTC block already in TBC, skipping peer request", "hash", hash)
+		return true
+	}
+
+	return false
+}
+
 // Equality function which can be used to compare hashes in-line without needing to store in a variable
 // to get pointer for using the built-in IsEqual function.
 // TODO: review, better way to compare hashes where this is called?

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -28,7 +28,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/hemilabs/heminetwork/cmd/btctool/bdf"
 	"github.com/hemilabs/heminetwork/service/tbc"
 	"github.com/holiman/uint256"
@@ -527,17 +526,7 @@ func (e *Ethereum) SendRequestForHashToAllPeers(hash common.Hash) {
 }
 
 func (e *Ethereum) RequestBitcoinBlocksFromPeers(hash common.Hash) bool {
-	var ch chainhash.Hash
-	if err := ch.SetBytes(hash.Bytes()); err != nil {
-		// should not happen, fail loudly if it does
-		log.Crit("Failed to convert hash for TBC lookup", "hash", hash, "err", err)
-	}
-	available, err := vm.TBCFullNode.FullBlockAvailable(vm.MainCtx, ch)
-	if err != nil {
-		// also should not happen, fail loudly if it does
-		log.Crit("Failed to check BTC block availability before peer request", "hash", hash, "err", err)
-	} else if available {
-		log.Trace("BTC block already in TBC, skipping peer request", "hash", hash)
+	if available := vm.BlockAvailableByCommonHash(hash); available {
 		return true
 	}
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -237,7 +237,7 @@ type BlockChain interface {
 }
 
 // New creates a new downloader to fetch hashes and blocks from remote peers.
-func New(stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, dropPeer peerDropFn, success func()) *Downloader {
+func New(stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, dropPeer peerDropFn, success func(), requestBtcBlocksFunc func(hash common.Hash)) *Downloader {
 	hVMSnapFunc := func(btcTipHeader *chainhash.Hash, hvmTipHeader *types.Header) {
 		log.Info("hVM Snap Sync Func called")
 		chain.SnapSyncHvm(btcTipHeader, hvmTipHeader)
@@ -254,7 +254,7 @@ func New(stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, dropPeer 
 		dropPeer:          dropPeer,
 		headerProcCh:      make(chan *headerTask, 1),
 		quitCh:            make(chan struct{}),
-		SnapSyncer:        snap.NewSyncer(stateDb, chain.TrieDB().Scheme(), hVMSnapFunc),
+		SnapSyncer:        snap.NewSyncer(stateDb, chain.TrieDB().Scheme(), hVMSnapFunc, requestBtcBlocksFunc),
 		stateSyncStart:    make(chan *stateSync),
 		syncStartBlock:    chain.CurrentSnapBlock().Number.Uint64(),
 	}

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -75,7 +75,7 @@ func newTesterWithNotification(t *testing.T, success func()) *downloadTester {
 		chain: chain,
 		peers: make(map[string]*downloadTesterPeer),
 	}
-	tester.downloader = New(db, new(event.TypeMux), tester.chain, tester.dropPeer, success)
+	tester.downloader = New(db, new(event.TypeMux), tester.chain, tester.dropPeer, success, nil)
 	return tester
 }
 

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -209,7 +209,14 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		return nil, errors.New("snap sync not supported with snapshots disabled")
 	}
 	// Construct the downloader (long sync)
-	h.downloader = downloader.New(config.Database, h.eventMux, h.chain, h.removePeer, h.enableSyncedFeatures)
+	requestBtcBlocksFromPeers := func(hash common.Hash) {
+		for _, peer := range h.peers.all() {
+			if err := peer.RequestBtcBlocks([]common.Hash{hash}); err != nil {
+				log.Error("Failed to request BTC block from peer during snap sync", "peer", peer.ID(), "hash", hash, "err", err)
+			}
+		}
+	}
+	h.downloader = downloader.New(config.Database, h.eventMux, h.chain, h.removePeer, h.enableSyncedFeatures, requestBtcBlocksFromPeers)
 
 	fetchTx := func(peer string, hashes []common.Hash) error {
 		p := h.peers.peer(peer)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -210,6 +210,10 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	}
 	// Construct the downloader (long sync)
 	requestBtcBlocksFromPeers := func(hash common.Hash) {
+		if available := vm.BlockAvailableByCommonHash(hash); available {
+			return
+		}
+
 		for _, peer := range h.peers.all() {
 			if err := peer.RequestBtcBlocks([]common.Hash{hash}); err != nil {
 				log.Error("Failed to request BTC block from peer during snap sync", "peer", peer.ID(), "hash", hash, "err", err)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/dchest/siphash"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	gomath "math"
 	"math/big"
 	"math/rand"
@@ -514,7 +515,8 @@ type Syncer struct {
 	pend sync.WaitGroup // Tracks network request goroutines for graceful shutdown
 	lock sync.RWMutex   // Protects fields that can change outside of sync (peers, reqs, root)
 
-	snapSyncHvm func(btcTipHeader *chainhash.Hash, hvmTipHeader *types.Header)
+	snapSyncHvm            func(btcTipHeader *chainhash.Hash, hvmTipHeader *types.Header)
+	requestBtcBlockFromPeers func(hash common.Hash)
 
 	hVMSnapHeaders []*types.Header
 	hVMSnapBlock   *types.Block
@@ -522,7 +524,7 @@ type Syncer struct {
 
 // NewSyncer creates a new snapshot syncer to download the Ethereum state over the
 // snap protocol.
-func NewSyncer(db ethdb.KeyValueStore, scheme string, snapSyncHvmFunc func(btcTipHeader *chainhash.Hash, hvmTipHeader *types.Header)) *Syncer {
+func NewSyncer(db ethdb.KeyValueStore, scheme string, snapSyncHvmFunc func(btcTipHeader *chainhash.Hash, hvmTipHeader *types.Header), requestBtcBlocksFunc func(hash common.Hash)) *Syncer {
 	return &Syncer{
 		db:     db,
 		scheme: scheme,
@@ -551,7 +553,8 @@ func NewSyncer(db ethdb.KeyValueStore, scheme string, snapSyncHvmFunc func(btcTi
 
 		extProgress: new(SyncProgress),
 
-		snapSyncHvm: snapSyncHvmFunc,
+		snapSyncHvm:              snapSyncHvmFunc,
+		requestBtcBlockFromPeers: requestBtcBlocksFunc,
 	}
 }
 
@@ -2893,6 +2896,18 @@ func (s *Syncer) OnHvmLightState(peer SyncPeer, id uint64, headers []*types.Head
 	if err != nil {
 		log.Warn(fmt.Sprintf("hVM light state error extracting Bitcoin Attributes Deposited tx from peer %s", peer.ID()), "err", err)
 		return fmt.Errorf("error extracting Bitcoin Attributes Deposited tx")
+	}
+
+	if s.requestBtcBlockFromPeers != nil {
+		go s.requestBtcBlockFromPeers(common.Hash(btcAttrDep.CanonicalTip))
+		for _, rawHeader := range btcAttrDep.Headers {
+			var bh wire.BlockHeader
+			if err := bh.Deserialize(bytes.NewReader(rawHeader[:])); err != nil {
+				log.Warn("hVM light state failed to parse Bitcoin header for peer request", "err", err)
+				continue
+			}
+			go s.requestBtcBlockFromPeers(common.Hash(bh.BlockHash()))
+		}
 	}
 
 	canonicalTip := btcAttrDep.CanonicalTip

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -630,7 +630,7 @@ func testSyncBloatedProof(t *testing.T, scheme string) {
 
 func setupSyncer(scheme string, peers ...*testPeer) *Syncer {
 	stateDb := rawdb.NewMemoryDatabase()
-	syncer := NewSyncer(stateDb, scheme, nil)
+	syncer := NewSyncer(stateDb, scheme, nil, nil)
 	for _, peer := range peers {
 		syncer.Register(peer)
 		peer.remote = syncer


### PR DESCRIPTION
similar to when forkchoiceUpdated gets called, upon receving an HvmLightStateMsg, ensure that we have the canonical tip and all headers within the bitcoin attributes deposited tx